### PR TITLE
Add SurveyCreationDate attribute mapping to survey

### DIFF
--- a/lib/qualtrics_api/survey.rb
+++ b/lib/qualtrics_api/survey.rb
@@ -1,7 +1,7 @@
 module QualtricsAPI
 
   class Survey
-    attr_accessor :id, :name, :owner_id, :last_modified, :status
+    attr_accessor :id, :name, :owner_id, :last_modified, :status, :created_at
 
     def initialize(options = {})
       attributes_mappings.each do |key, qualtrics_key|
@@ -22,7 +22,8 @@ module QualtricsAPI
         :name => "name",
         :owner_id => "ownerId",
         :last_modified => "lastModified",
-        :status => "status"
+        :status => "status",
+        :created_at => "SurveyCreationDate"
       }
     end
   end

--- a/spec/lib/survey_spec.rb
+++ b/spec/lib/survey_spec.rb
@@ -8,7 +8,8 @@ describe QualtricsAPI::Survey do
       "name" => "test_survey",
       "ownerId" => "UR_3fnAz35QCGlr725",
       "lastModified" => "2015-03-20 12:56:33",
-      "status" => "Inactive"
+      "status" => "Inactive",
+      "SurveyCreationDate" => "2015-03-20 12:56:33"
     }
   end
 
@@ -30,6 +31,10 @@ describe QualtricsAPI::Survey do
 
   it "has last_modified" do
     expect(subject.last_modified).to eq qualtrics_response["lastModified"]
+  end
+
+  it "has created_at" do
+    expect(subject.created_at).to eq qualtrics_response["SurveyCreationDate"]
   end
 
   it "has status" do


### PR DESCRIPTION
This is beacase that on  class QualtricsSurveySyncWorker we are saving SurveyCreationDate attribute from qualtrics to our db.

```
class QualtricsSurveySyncWorker
  include Sidekiq::Worker

  sidekiq_options queue: :qualtrics_api, unique: true

  def perform
    qualtrics_client = Qualtrics::Client.new
    surveys = qualtrics_client.get_surveys
    if surveys
      surveys.each do |s|
        survey = Import::QualtricsSurvey.find_or_initialize_by(survey_id: s["SurveyID"])
        survey.update_attributes(
          survey_name: s["SurveyName"],
          survey_status: s["SurveyStatus"],
          survey_creation_date: s["SurveyCreationDate"],
          last_modified: s["LastModified"]
          )
      end
    end
  end
end
```
