### PR TITLE
API can be both accessed globally or from a client instance

### DIFF
--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -31,6 +31,25 @@ require "qualtrics_api/services/response_export_service"
 module QualtricsAPI
   class << self
     include QualtricsAPI::Configurable
-    include QualtricsAPI::Client
+
+    def connection(parent = nil)
+      return parent.connection if parent
+      @client ||= QualtricsAPI::Client.new(QualtricsAPI.api_token)
+      @client.connection
+    end
+
+    # to be extracted to a module
+    def surveys(options = {})
+      @surveys = nil if @surveys && @surveys.scope_id != options[:scope_id]
+      @surveys ||= QualtricsAPI::SurveyCollection.new(options)
+    end
+
+    def response_exports(options = {})
+      @response_exports ||= QualtricsAPI::ResponseExportCollection.new(options)
+    end
+
+    def panels(options = {})
+      @panels ||= QualtricsAPI::PanelCollection.new(options)
+    end
   end
 end

--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -16,6 +16,7 @@ require "qualtrics_api/extensions/serializable_model"
 require "qualtrics_api/extensions/serializable_collection"
 
 require "qualtrics_api/base_model"
+require "qualtrics_api/base_collection"
 
 require "qualtrics_api/survey"
 require "qualtrics_api/survey_collection"
@@ -39,9 +40,11 @@ module QualtricsAPI
     def_delegator :client, :panels
 
     def connection(parent = nil)
-      return parent.connection if parent
+      return parent.connection if parent && parent.connection
       client.connection
     end
+
+    private
 
     def client
       @client ||= QualtricsAPI::Client.new(QualtricsAPI.api_token)

--- a/lib/qualtrics_api.rb
+++ b/lib/qualtrics_api.rb
@@ -9,6 +9,7 @@ require "qualtrics_api/url"
 require "qualtrics_api/request_error_handler"
 
 require "qualtrics_api/configurable"
+require "qualtrics_api/connectable"
 require "qualtrics_api/client"
 
 require "qualtrics_api/extensions/serializable_model"
@@ -31,25 +32,19 @@ require "qualtrics_api/services/response_export_service"
 module QualtricsAPI
   class << self
     include QualtricsAPI::Configurable
+    extend Forwardable
+
+    def_delegator :client, :surveys
+    def_delegator :client, :response_exports
+    def_delegator :client, :panels
 
     def connection(parent = nil)
       return parent.connection if parent
+      client.connection
+    end
+
+    def client
       @client ||= QualtricsAPI::Client.new(QualtricsAPI.api_token)
-      @client.connection
-    end
-
-    # to be extracted to a module
-    def surveys(options = {})
-      @surveys = nil if @surveys && @surveys.scope_id != options[:scope_id]
-      @surveys ||= QualtricsAPI::SurveyCollection.new(options)
-    end
-
-    def response_exports(options = {})
-      @response_exports ||= QualtricsAPI::ResponseExportCollection.new(options)
-    end
-
-    def panels(options = {})
-      @panels ||= QualtricsAPI::PanelCollection.new(options)
     end
   end
 end

--- a/lib/qualtrics_api/base_collection.rb
+++ b/lib/qualtrics_api/base_collection.rb
@@ -1,0 +1,12 @@
+module QualtricsAPI
+  class BaseCollection
+    extend Forwardable
+    include Enumerable
+    include Virtus.value_object
+    include QualtricsAPI::Extensions::SerializableCollection
+    include QualtricsAPI::Connectable
+
+    def_delegator :all, :each
+    def_delegator :all, :size
+  end
+end

--- a/lib/qualtrics_api/base_model.rb
+++ b/lib/qualtrics_api/base_model.rb
@@ -2,8 +2,10 @@ module QualtricsAPI
   class BaseModel
     include Virtus.value_object
     include QualtricsAPI::Extensions::SerializableModel
+    include QualtricsAPI::Connectable
 
     def initialize(options = {})
+      @connection = options[:connection]
       attributes_mappings.each do |key, qualtrics_key|
         instance_variable_set "@#{key}", options[qualtrics_key]
       end

--- a/lib/qualtrics_api/base_model.rb
+++ b/lib/qualtrics_api/base_model.rb
@@ -15,6 +15,5 @@ module QualtricsAPI
     def attributes_mappings
       {}
     end
-
   end
 end

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -1,6 +1,6 @@
 module QualtricsAPI
   class Client
-    attr_reader :connection
+    include QualtricsAPI::Connectable
 
     def initialize(api_token)
       @connection = establish_connection(api_token || fail('Please provide api token!'))

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -1,10 +1,10 @@
 module QualtricsAPI
   class Client
+    include QualtricsAPI::Connectable
     attr_reader :connection
 
     def initialize(api_token)
-      fail('Please provide api token!') unless api_token
-      @connection = establish_connection(api_token)
+      @connection = establish_connection(api_token || fail('Please provide api token!'))
     end
 
     def surveys(options = {})

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -1,6 +1,11 @@
 module QualtricsAPI
-  module Client
-    include Virtus.value_object
+  class Client
+    attr_reader :connection
+
+    def initialize(api_token)
+      fail('Please provide api token!') unless api_token
+      @connection = establish_connection(api_token)
+    end
 
     def surveys(options = {})
       @surveys = nil if @surveys && @surveys.scope_id != options[:scope_id]
@@ -15,9 +20,10 @@ module QualtricsAPI
       @panels ||= QualtricsAPI::PanelCollection.new(options)
     end
 
-    def connection
-      api_token ||= QualtricsAPI.api_token || fail('Please configure api token!')
-      @conn ||= Faraday.new(url: QualtricsAPI::URL, params: { apiToken: api_token }) do |faraday|
+    private
+
+    def establish_connection(api_token)
+      Faraday.new(url: QualtricsAPI::URL, params: { apiToken: api_token }) do |faraday|
         faraday.request :url_encoded
         faraday.response :json, :content_type => /\bjson$/
 

--- a/lib/qualtrics_api/client.rb
+++ b/lib/qualtrics_api/client.rb
@@ -1,6 +1,5 @@
 module QualtricsAPI
   class Client
-    include QualtricsAPI::Connectable
     attr_reader :connection
 
     def initialize(api_token)
@@ -9,15 +8,15 @@ module QualtricsAPI
 
     def surveys(options = {})
       @surveys = nil if @surveys && @surveys.scope_id != options[:scope_id]
-      @surveys ||= QualtricsAPI::SurveyCollection.new(options)
+      @surveys ||= QualtricsAPI::SurveyCollection.new(options).propagate_connection(self)
     end
 
     def response_exports(options = {})
-      @response_exports ||= QualtricsAPI::ResponseExportCollection.new(options)
+      @response_exports ||= QualtricsAPI::ResponseExportCollection.new(options).propagate_connection(self)
     end
 
     def panels(options = {})
-      @panels ||= QualtricsAPI::PanelCollection.new(options)
+      @panels ||= QualtricsAPI::PanelCollection.new(options).propagate_connection(self)
     end
 
     private

--- a/lib/qualtrics_api/connectable.rb
+++ b/lib/qualtrics_api/connectable.rb
@@ -1,0 +1,4 @@
+module QualtricsAPI::Connectable
+  attr_reader :connection
+
+end

--- a/lib/qualtrics_api/connectable.rb
+++ b/lib/qualtrics_api/connectable.rb
@@ -1,4 +1,10 @@
-module QualtricsAPI::Connectable
-  attr_reader :connection
-
+module QualtricsAPI
+  module Connectable
+    attr_reader :connection
+  
+    def propagate_connection(connectable)
+      @connection = connectable.connection
+      self
+    end
+  end
 end

--- a/lib/qualtrics_api/panel.rb
+++ b/lib/qualtrics_api/panel.rb
@@ -8,7 +8,7 @@ module QualtricsAPI
     end
 
     def members(options = {})
-      @members ||= QualtricsAPI::PanelMemberCollection.new(options.merge(id: id))
+      @members ||= QualtricsAPI::PanelMemberCollection.new(options.merge(id: id)).propagate_connection(self)
     end
 
     private

--- a/lib/qualtrics_api/panel_collection.rb
+++ b/lib/qualtrics_api/panel_collection.rb
@@ -1,20 +1,12 @@
 module QualtricsAPI
-  class PanelCollection
-    extend Forwardable
-    include Enumerable
-    include Virtus.value_object
-    include QualtricsAPI::Extensions::SerializableCollection
-
+  class PanelCollection < BaseCollection
     values do
       attribute :all, Array, :default => []
     end
 
-    def_delegator :all, :each
-    def_delegator :all, :size
-
     def fetch(_options = {})
       @all = []
-      parse_fetch_response(QualtricsAPI.connection.get('panels'))
+      parse_fetch_response(QualtricsAPI.connection(self).get('panels'))
       self
     end
 
@@ -25,14 +17,14 @@ module QualtricsAPI
     def find(panel_id)
       @all.detect do |panel|
         panel.id == panel_id
-      end || QualtricsAPI::Panel.new("panelId" => panel_id)
+      end || QualtricsAPI::Panel.new("panelId" => panel_id).propagate_connection(self)
     end
 
     private
 
     def parse_fetch_response(response)
       @all = response.body["result"].map do |result|
-        QualtricsAPI::Panel.new(result)
+        QualtricsAPI::Panel.new(result).propagate_connection(self)
       end
     end
   end

--- a/lib/qualtrics_api/panel_import.rb
+++ b/lib/qualtrics_api/panel_import.rb
@@ -1,14 +1,12 @@
 module QualtricsAPI
-  class PanelImport
-    include Virtus.value_object
-
+  class PanelImport < BaseModel
     values do
       attribute :id, String
       attribute :panel_id, String
     end
 
     def update_status
-      res = QualtricsAPI.connection.get("panels/#{panel_id}/members/panelImports/#{id}").body["result"]
+      res = QualtricsAPI.connection(self).get("panels/#{panel_id}/members/panelImports/#{id}").body["result"]
       @import_progress = res["percentComplete"]
       @completed = true if @import_progress == 100.0
       self

--- a/lib/qualtrics_api/panel_member_collection.rb
+++ b/lib/qualtrics_api/panel_member_collection.rb
@@ -1,29 +1,22 @@
 module QualtricsAPI
-  class PanelMemberCollection
-    extend Forwardable
-    include Enumerable
-    include Virtus.value_object
-
+  class PanelMemberCollection < BaseCollection
     values do
       attribute :id, String
       attribute :all, Array, :default => []
     end
   
-    def_delegator :all, :each
-    def_delegator :all, :size
-
     def fetch(_options = {})
       @all = []
-      parse_fetch_response(QualtricsAPI.connection.get("panels/#{id}/members"))
+      parse_fetch_response(QualtricsAPI.connection(self).get("panels/#{id}/members"))
       self
     end
 
     def create(panel_members)
-      res = QualtricsAPI.connection
-            .post("panels/#{id}/members", QualtricsAPI.connection.params.merge(panelMembers: panel_members.to_json))
+      res = QualtricsAPI.connection(self)
+            .post("panels/#{id}/members", QualtricsAPI.connection(self).params.merge(panelMembers: panel_members.to_json))
             .body["result"]
       import_id = res['importStatus'].split('/').last
-      QualtricsAPI::PanelImport.new(id: import_id, panel_id: id)
+      QualtricsAPI::PanelImport.new(id: import_id, panel_id: id).propagate_connection(self)
     end
 
     def [](member_id)
@@ -33,14 +26,14 @@ module QualtricsAPI
     def find(member_id)
       @all.detect do |panel_member|
         panel_member.id == member_id
-      end || QualtricsAPI::PanelMember.new(:id => member_id)
+      end || QualtricsAPI::PanelMember.new(:id => member_id).propagate_connection(self)
     end
 
     private
 
     def parse_fetch_response(response)
       @all = response.body["result"].map do |result|
-        QualtricsAPI::PanelMember.new(result)
+        QualtricsAPI::PanelMember.new(result).propagate_connection(self)
       end
     end
   end

--- a/lib/qualtrics_api/response_export.rb
+++ b/lib/qualtrics_api/response_export.rb
@@ -1,13 +1,11 @@
 module QualtricsAPI
-  class ResponseExport
-    include Virtus.value_object
-
+  class ResponseExport < BaseModel
     values do
       attribute :id, String
     end
 
     def update_status
-      res = QualtricsAPI.connection.get('surveys/responseExports/' + id).body["result"]
+      res = QualtricsAPI.connection(self).get('surveys/responseExports/' + id).body["result"]
       @export_progress = res["percentComplete"]
       @file_url = res["fileUrl"]
       @completed = true if @export_progress == 100.0

--- a/lib/qualtrics_api/response_export_collection.rb
+++ b/lib/qualtrics_api/response_export_collection.rb
@@ -1,15 +1,8 @@
 module QualtricsAPI
-  class ResponseExportCollection
-    extend Forwardable
-    include Enumerable
-    include Virtus.value_object
-
+  class ResponseExportCollection < BaseCollection
     values do
       attribute :all, Array, :default => []
     end
-
-    def_delegator :all, :each
-    def_delegator :all, :size
 
     def [](export_id)
       find(export_id)
@@ -18,7 +11,7 @@ module QualtricsAPI
     def find(export_id)
       @all.detect do |response_export|
         response_export.id == export_id
-      end || QualtricsAPI::ResponseExport.new(:id => export_id)
+      end || QualtricsAPI::ResponseExport.new(:id => export_id).propagate_connection(self)
     end
   end
 end

--- a/lib/qualtrics_api/services/response_export_service.rb
+++ b/lib/qualtrics_api/services/response_export_service.rb
@@ -1,28 +1,28 @@
 module QualtricsAPI
   module Services
-    class ResponseExportService
-      include Virtus.value_object
-
-      attribute :survey_id, String
-      attribute :response_set_id, String
-      attribute :file_type, String, :default => 'CSV'
-      attribute :last_response_id, String
-      attribute :start_date, String
-      attribute :end_date, String
-      attribute :limit, String
-      attribute :included_question_ids, String
-      attribute :max_rows, String
-      attribute :use_labels, Boolean, :default => false
-      attribute :decimal_format, String, :default => '.'
-      attribute :seen_unanswered_recode, String
-      attribute :use_local_time, Boolean, :default => false
-      attribute :spss_string_length, String
-      attribute :id, String
+    class ResponseExportService < QualtricsAPI::BaseModel
+      values do
+        attribute :survey_id, String
+        attribute :response_set_id, String
+        attribute :file_type, String, :default => 'CSV'
+        attribute :last_response_id, String
+        attribute :start_date, String
+        attribute :end_date, String
+        attribute :limit, String
+        attribute :included_question_ids, String
+        attribute :max_rows, String
+        attribute :use_labels, Boolean, :default => false
+        attribute :decimal_format, String, :default => '.'
+        attribute :seen_unanswered_recode, String
+        attribute :use_local_time, Boolean, :default => false
+        attribute :spss_string_length, String
+        attribute :id, String
+      end
       
       attr_reader :result
 
       def start
-        response = QualtricsAPI.connection.get("surveys/#{survey_id}/responseExports", export_params)
+        response = QualtricsAPI.connection(self).get("surveys/#{survey_id}/responseExports", export_params)
         export_id = response.body["result"]["exportStatus"].split('/').last
         @result = ResponseExport.new(id: export_id)
       end

--- a/lib/qualtrics_api/survey.rb
+++ b/lib/qualtrics_api/survey.rb
@@ -10,7 +10,7 @@ module QualtricsAPI
     end
 
     def export_responses(export_options = {})
-      QualtricsAPI::Services::ResponseExportService.new(export_options.merge(survey_id: id))
+      QualtricsAPI::Services::ResponseExportService.new(export_options.merge(survey_id: id)).propagate_connection(self)
     end
 
     private

--- a/lib/qualtrics_api/survey_collection.rb
+++ b/lib/qualtrics_api/survey_collection.rb
@@ -1,9 +1,5 @@
 module QualtricsAPI
-  class SurveyCollection
-    extend Forwardable
-    include Enumerable
-    include Virtus.value_object
-
+  class SurveyCollection < BaseCollection
     values do
       attribute :scope_id, String
       attribute :all, Array, :default => []
@@ -11,13 +7,10 @@ module QualtricsAPI
 
     attr_writer :scope_id
 
-    def_delegator :all, :each
-    def_delegator :all, :size
-
     def fetch(options = {})
       @all = []
       update_query_attributes(options)
-      parse_fetch_response(QualtricsAPI.connection.get('surveys', query_params))
+      parse_fetch_response(QualtricsAPI.connection(self).get('surveys', query_params))
       self
     end
 
@@ -57,7 +50,7 @@ module QualtricsAPI
 
     def parse_fetch_response(response)
       @all = response.body["result"].map do |result|
-        QualtricsAPI::Survey.new result
+        QualtricsAPI::Survey.new(result).propagate_connection(self)
       end
     end
   end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -26,4 +26,16 @@ describe QualtricsAPI::Client do
       expect(subject.surveys.object_id).to eq subject.surveys.object_id
     end
   end
+
+  describe "#initialize" do
+    subject { QualtricsAPI::Client }
+
+    it "fails if api_token not provided" do
+      expect { subject.new(nil) }.to raise_error('Please provide api token!')
+    end
+
+    it 'establishes connection when api_token' do
+      subject.new('sample_token')
+    end
+  end
 end

--- a/spec/lib/survey_spec.rb
+++ b/spec/lib/survey_spec.rb
@@ -47,7 +47,7 @@ describe QualtricsAPI::Survey do
 
     it "inits a ResponseExportService with options" do
       expect(QualtricsAPI::Services::ResponseExportService).to receive(:new).with(start_date: options[:start_date],
-                                                                                  survey_id: subject.id)
+                                                                                  survey_id: subject.id).and_return(QualtricsAPI::Services::ResponseExportService.new)
 
       subject.export_responses(options)
     end

--- a/spec/qualtrics_api_spec.rb
+++ b/spec/qualtrics_api_spec.rb
@@ -4,8 +4,25 @@ describe QualtricsAPI do
   describe "#new" do
     subject { QualtricsAPI }
 
-    it "initializes a Client with the token passed" do
-      expect(subject).to be_kind_of(QualtricsAPI::Client)
+    it 'two clients have different connection' do
+      client_1 = QualtricsAPI::Client.new('some_id')
+      client_2 = QualtricsAPI::Client.new('other_id')
+      expect(client_1.connection).not_to eq(client_2.connection)
+    end
+
+    it 'reuses connection if globally configured' do
+      QualtricsAPI.configure do |config|
+        config.api_token = 'some_id'
+      end
+      expect(QualtricsAPI.connection).to eq(QualtricsAPI.connection)
+    end
+
+    it 'does not reuse connection with client' do
+      client = QualtricsAPI::Client.new('some_id')
+      QualtricsAPI.configure do |config|
+        config.api_token = 'some_id'
+      end
+      expect(client.connection).not_to eq(QualtricsAPI.connection)
     end
   end
 end

--- a/spec/qualtrics_api_spec.rb
+++ b/spec/qualtrics_api_spec.rb
@@ -42,6 +42,23 @@ describe QualtricsAPI do
         it 'has propagated exception to members' do
           expect(members.connection).to eq(client.connection)
         end
+      
+        context 'with different client' do
+          let(:client_2) { QualtricsAPI::Client.new(TEST_API_TOKEN) }
+          let(:members_2) do
+            VCR.use_cassette('panel_member_collection_create_success') do
+              client_2.panels.fetch['ML_bC2c5xBz1DxyOYB'].members
+            end
+          end
+
+          it 'has propagated exception to members' do
+            expect(members_2.connection).to eq(client_2.connection)
+          end
+
+          it 'does not conflict with different client' do
+            expect(client_2.connection).not_to eq(client.connection)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
- [x] Refactor base model to a module
- [x] Introduce object for holding connection and pass it to QualtricsApi automatically 
