### PR TITLE
A method for opening file passing the connection headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,12 @@ export.completed?
 Once it's finished, you can get the response file URL:
 ```ruby
 export.file_url
-# => "https://some.amazon.s3.com/file/path?withTimeStamps=AndOtherStuff"
+# => "https://co1.qualtrics.com/API/v3/responseexports/ES_id/file"
+```
+
+and download the file:
+```ruby
+export.open # creates an IO object connected to the given stream
 ```
 
 #### Checking status on a previous response export

--- a/lib/qualtrics_api/response_export.rb
+++ b/lib/qualtrics_api/response_export.rb
@@ -30,5 +30,9 @@ module QualtricsAPI
       update_status unless completed?
       @file_url
     end
+
+    def open(&block)
+      Kernel.open(@file_url, QualtricsAPI.connection(self).headers, &block)
+    end
   end
 end


### PR DESCRIPTION
That should allow to download the file directly using:

``` ruby
export = export_service.start
if export.completed?
  Zip::File.open(export.open) do |zip|
    # do sth with a zip
  end
end
```

but let me test it a little bit
