### PR TITLE
Return true/false depending on delete response status code

### DIFF
--- a/lib/qualtrics_api/event_subscription.rb
+++ b/lib/qualtrics_api/event_subscription.rb
@@ -10,9 +10,9 @@ module QualtricsAPI
     end
 
     def delete
-      QualtricsAPI.connection(self)
+      response = QualtricsAPI.connection(self)
         .delete(endpoint)
-        .body["result"]
+      return response.success?
     end
 
     private

--- a/lib/qualtrics_api/event_subscription.rb
+++ b/lib/qualtrics_api/event_subscription.rb
@@ -10,9 +10,9 @@ module QualtricsAPI
     end
 
     def delete
-      response = QualtricsAPI.connection(self)
+      QualtricsAPI.connection(self)
         .delete(endpoint)
-      return response.success?
+      return true
     end
 
     private

--- a/spec/lib/event_subscription_spec.rb
+++ b/spec/lib/event_subscription_spec.rb
@@ -43,7 +43,8 @@ describe QualtricsAPI::EventSubscription do
       VCR.use_cassette("event_subscription_delete") do
         sub_id = 'SUB_2i7QDi3PXEK4eqx'
         subscription = QualtricsAPI.event_subscriptions.find(sub_id)
-        subscription.delete
+        result = subscription.delete
+        expect(result).to be_truthy
         expect {
           QualtricsAPI.event_subscriptions.find(sub_id)
         }.to raise_error(QualtricsAPI::NotFoundError)


### PR DESCRIPTION
EventSubscription#delete returns true if status code in success range, otherwise returns false (previously would always return nil because no body in Qualtrics response)